### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/JohnEriksson0461/91fb2d33-50d9-4591-9572-fd4e304d2bc9/6842c6fb-c77e-4c4e-a859-f85e2003e5bc/_apis/work/boardbadge/efcee860-7560-49e5-b39f-636a613cdefe)](https://dev.azure.com/JohnEriksson0461/91fb2d33-50d9-4591-9572-fd4e304d2bc9/_boards/board/t/6842c6fb-c77e-4c4e-a859-f85e2003e5bc/Microsoft.RequirementCategory)
 ## Random Wheel
 
 <img src='http://i.imgur.com/BW9WbDg.png' width=450/>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://dev.azure.com/JohnEriksson0461/91fb2d33-50d9-4591-9572-fd4e304d2bc9/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.